### PR TITLE
fixed phantomPatternsPath for document generation

### DIFF
--- a/framework/src/Degradations/PhantomCharacter.hpp
+++ b/framework/src/Degradations/PhantomCharacter.hpp
@@ -27,8 +27,8 @@ public :
   /*
 
    */
-  explicit PhantomCharacter(const QImage &original, Frequency frequency, QObject *parent =0) :
-    DocumentDegradation(parent), _frequency(frequency), _original(original)
+  explicit PhantomCharacter(const QImage &original, Frequency frequency, const QString &phantomPatternsPath, QObject *parent =0) :
+    DocumentDegradation(parent), _frequency(frequency), _phantomPatternsPath(phantomPatternsPath), _original(original)
   {}
 
 public slots :

--- a/software/DocCreator/src/Degradations/PhantomCharacterDialog.cpp
+++ b/software/DocCreator/src/Degradations/PhantomCharacterDialog.cpp
@@ -24,7 +24,8 @@ PhantomCharacterDialog::PhantomCharacterDialog(QWidget *parent)
   _frequency = (Frequency)ui->frequencyComboBox->currentIndex();
   _zoomX = ZOOM_X_INIT;
   _zoomY = ZOOM_Y_INIT;
-  _phantomPatternsPath = "../share/DocCreator/data/Image/phantomPatterns/";
+  _phantomPatternsPath = Context::BackgroundContext::instance()->getPath() +
+         "../Image/phantomPatterns/"; //B:TODO:UGLY !
 
   ui->xSlider->setValue(_zoomX);
   ui->ySlider->setValue(_zoomY);

--- a/software/DocCreator/src/GenerateDocument/Assistant.cpp
+++ b/software/DocCreator/src/GenerateDocument/Assistant.cpp
@@ -2341,7 +2341,8 @@ Assistant::Phantom_apply(Frequency frequency)
 {
   PhantomCharacter phant(
     _Phantom_rectoImgPartPhant,
-    frequency); //B? should we apply on big image and takePart afterwards ?
+    frequency,
+    _PhantomPatternsPath); //B? should we apply on big image and takePart afterwards ?
   QImage Deg = phant.apply();
   ui->PhantomPreviewLabel->setPixmap(QPixmap::fromImage(Deg));
   ui->PhantomPreviewLabel->setMinimumSize(Deg.size());
@@ -4796,7 +4797,7 @@ Phantom_getFrequencyStr(Frequency frequency)
 static void
 Phantom_applyAndSave(const QImage &recto,
                      Frequency frequency,
-                     QString phantomPatternsPath,
+                     const QString &phantomPatternsPath,
                      int i,
                      const QString &imageBasename,
                      const QString &outputImageDir)
@@ -4840,14 +4841,14 @@ Assistant::do_phantom(const QString &imageBasename,
 
     if (ui->Phantom_Rare->isChecked()) {
       Phantom_applyAndSave(
-        recto, Frequency::RARE, this->_PhantomPatternsPath, i, imageBasename, outputImageDir);
+        recto, Frequency::RARE, _PhantomPatternsPath, i, imageBasename, outputImageDir);
 
       qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
     }
 
     if (ui->Phantom_Frequent->isChecked()) {
       Phantom_applyAndSave(
-        recto, Frequency::FREQUENT, this->_PhantomPatternsPath, i, imageBasename, outputImageDir);
+        recto, Frequency::FREQUENT, _PhantomPatternsPath, i, imageBasename, outputImageDir);
 
       qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
     }
@@ -4855,7 +4856,7 @@ Assistant::do_phantom(const QString &imageBasename,
     if (ui->Phantom_VeryFrequent->isChecked()) {
 
       Phantom_applyAndSave(
-        recto, Frequency::VERY_FREQUENT, this->_PhantomPatternsPath, i, imageBasename, outputImageDir);
+        recto, Frequency::VERY_FREQUENT, _PhantomPatternsPath, i, imageBasename, outputImageDir);
 
       qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
     }


### PR DESCRIPTION
Previous commits were only working for the degradation part of the software, the explicit constructor had been forgotten and it caused error when previewing `PhantomCharacters` during the document generation process, this commit fixes that.

Tested on simple document degradation and on document generation (full process), working on both this time.
Sorry for the inconvenience.