### PR TITLE
Turn on installing framework library

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -143,12 +143,12 @@ INSTALL(FILES ${headers_patterns} DESTINATION include/DocCreatorFramework/patter
 INSTALL(FILES ${Degradations_headers} DESTINATION include/DocCreatorFramework/Degradations)
 INSTALL(FILES ${Utils_headers} DESTINATION include/DocCreatorFramework/Utils)
 
-#INSTALL(TARGETS DocCreatorFramework
-#        #FRAMEWORK DESTINATION /Library/Frameworks
-#        RUNTIME DESTINATION bin
-#        LIBRARY DESTINATION lib
-#        ARCHIVE DESTINATION lib
-#)
+INSTALL(TARGETS DocCreatorFramework
+        #FRAMEWORK DESTINATION /Library/Frameworks
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+)
 
 #B: useless ???
 #INSTALL(FILES DocCreatorFramework.pc DESTINATION lib/pkgconfig)


### PR DESCRIPTION
I use the framework library directly in my code and I need to link against it, this PR turns on installing of the shared library to system directories which was commented out for some reason. 